### PR TITLE
추천 사용자 Entity, 습관 본문 categoryId, 사용자 상세 페이지, 마이페이지

### DIFF
--- a/src/main/java/com/sollertia/habit/domain/completedhabbit/repository/CompletedHabitRepository.java
+++ b/src/main/java/com/sollertia/habit/domain/completedhabbit/repository/CompletedHabitRepository.java
@@ -10,4 +10,6 @@ import java.util.List;
 public interface CompletedHabitRepository extends JpaRepository<CompletedHabit, Long> {
 
     List<CompletedHabit> findAllByUserAndStartDateBetweenOrderByStartDate(User user, LocalDate start, LocalDate end);
+
+    Integer countByUser(User user);
 }

--- a/src/main/java/com/sollertia/habit/domain/habit/dto/HabitDetail.java
+++ b/src/main/java/com/sollertia/habit/domain/habit/dto/HabitDetail.java
@@ -22,6 +22,7 @@ public class HabitDetail {
     private Boolean isAccomplished;
     private String practiceDays;
     private Long achievePercentage;
+    private Long categoryId;
     private Category category;
     private int achieveCount;
     private int totalCount;
@@ -46,6 +47,7 @@ public class HabitDetail {
                 .practiceDays(habit.getPracticeDays())
                 .current(habit.getCurrent())
                 .achievePercentage(habit.getAchievePercentage())
+                .categoryId(habit.getCategory().getCategoryId())
                 .category(habit.getCategory())
                 .achieveCount(Math.toIntExact(habit.getAccomplishCounter() * habit.getGoalCountInSession() +
                         (habit.getIsAccomplishInSession() ? 0 : habit.getCurrent())))

--- a/src/main/java/com/sollertia/habit/domain/habit/dto/HabitSummaryVo.java
+++ b/src/main/java/com/sollertia/habit/domain/habit/dto/HabitSummaryVo.java
@@ -23,6 +23,7 @@ public class HabitSummaryVo {
     private String practiceDays;
     private Long achievePercentage;
     private Category category;
+    private Long categoryId;
     private int achieveCount;
     private int totalCount;
 
@@ -47,6 +48,7 @@ public class HabitSummaryVo {
                 .current(habit.getCurrent())
                 .achievePercentage(habit.getAchievePercentage())
                 .category(habit.getCategory())
+                .categoryId(habit.getCategory().getCategoryId())
                 .achieveCount(Math.toIntExact(habit.getAccomplishCounter() * habit.getGoalCountInSession() +
                         (habit.getIsAccomplishInSession() ? 0 : habit.getCurrent())))
                 .totalCount(Math.toIntExact(habit.getWholeDays() * habit.getGoalCountInSession()))

--- a/src/main/java/com/sollertia/habit/domain/habit/repository/HabitRepository.java
+++ b/src/main/java/com/sollertia/habit/domain/habit/repository/HabitRepository.java
@@ -19,4 +19,6 @@ public interface HabitRepository<T extends Habit> extends JpaRepository<T, Long>
     List<Habit> findTodayHabitListByUser(@Param("user") User user,@Param("day") int day,@Param("today") LocalDate today);
 
     List<Habit> findByUser(User user);
+
+    Integer countByUser(User user);
 }

--- a/src/main/java/com/sollertia/habit/domain/habit/repository/HabitRepository.java
+++ b/src/main/java/com/sollertia/habit/domain/habit/repository/HabitRepository.java
@@ -18,7 +18,7 @@ public interface HabitRepository<T extends Habit> extends JpaRepository<T, Long>
             "order by h.isAccomplishInSession, h.createdAt desc")
     List<Habit> findTodayHabitListByUser(@Param("user") User user,@Param("day") int day,@Param("today") LocalDate today);
 
-    List<Habit> findByUser(User user);
+    List<Habit> findByUserOrderByCreatedAtDesc(User user);
 
     Integer countByUser(User user);
 }

--- a/src/main/java/com/sollertia/habit/domain/habit/service/HabitServiceImpl.java
+++ b/src/main/java/com/sollertia/habit/domain/habit/service/HabitServiceImpl.java
@@ -54,6 +54,7 @@ public class HabitServiceImpl implements HabitService {
                 .achievePercentage(savedHabit.getAchievePercentage())
                 .practiceDays(savedHabit.getPracticeDays())
                 .current(savedHabit.getCurrent())
+                .categoryId(savedHabit.getCategory().getCategoryId())
                 .title(savedHabit.getTitle())
                 .isAccomplished(false)
                 .build();
@@ -75,6 +76,7 @@ public class HabitServiceImpl implements HabitService {
         HabitDetail build = HabitDetail.builder()
                 .habitId(foundHabit.getId())
                 .category(foundHabit.getCategory())
+                .categoryId(foundHabit.getCategory().getCategoryId())
                 .count(foundHabit.getGoalCountInSession())
                 .totalCount(Math.toIntExact(foundHabit.getGoalCountInSession() * foundHabit.getWholeDays()))
                 .description(foundHabit.getDescription())

--- a/src/main/java/com/sollertia/habit/domain/habit/service/HabitServiceImpl.java
+++ b/src/main/java/com/sollertia/habit/domain/habit/service/HabitServiceImpl.java
@@ -185,7 +185,7 @@ public class HabitServiceImpl implements HabitService {
     }
 
     public List<HabitSummaryVo> getHabitListByUser(User user) {
-        List<Habit> habits = habitRepository.findByUser(user);
+        List<Habit> habits = habitRepository.findByUserOrderByCreatedAtDesc(user);
         return HabitSummaryVo.listOf(habits);
     }
 

--- a/src/main/java/com/sollertia/habit/domain/habit/service/HabitServiceImpl.java
+++ b/src/main/java/com/sollertia/habit/domain/habit/service/HabitServiceImpl.java
@@ -186,4 +186,10 @@ public class HabitServiceImpl implements HabitService {
         List<Habit> habits = habitRepository.findByUser(user);
         return HabitSummaryVo.listOf(habits);
     }
+
+    public Integer getAllHabitCountByUser(User user) {
+        Integer currentHabitCount = habitRepository.countByUser(user);
+        Integer complatedHabitCount = completedHabitRepository.countByUser(user);
+        return currentHabitCount+complatedHabitCount;
+    }
 }

--- a/src/main/java/com/sollertia/habit/domain/user/controller/MyPageResponseDto.java
+++ b/src/main/java/com/sollertia/habit/domain/user/controller/MyPageResponseDto.java
@@ -1,0 +1,14 @@
+package com.sollertia.habit.domain.user.controller;
+
+import com.sollertia.habit.domain.monster.dto.MonsterVo;
+import com.sollertia.habit.domain.user.dto.UserDetailsVo;
+import com.sollertia.habit.global.utils.DefaultResponseDto;
+import lombok.Getter;
+import lombok.experimental.SuperBuilder;
+
+@SuperBuilder
+@Getter
+public class MyPageResponseDto extends DefaultResponseDto {
+    UserDetailsVo userInfo;
+    MonsterVo monster;
+}

--- a/src/main/java/com/sollertia/habit/domain/user/controller/UserController.java
+++ b/src/main/java/com/sollertia/habit/domain/user/controller/UserController.java
@@ -45,7 +45,7 @@ public class UserController {
         return userService.disableUser(userDetails.getUser());
     }
 
-    @ApiOperation(value = "특정 유저 정보 조회", notes = "사용자, 몬스터, 습관 정보 응답")
+    @ApiOperation(value = "사용자 마이페이지 정보 조회", notes = "사용자, 몬스터 정보 응답")
     @GetMapping("/user/detail")
     public MyPageResponseDto getUserDetailInfo(
             @ApiIgnore @AuthenticationPrincipal UserDetailsImpl userDetails

--- a/src/main/java/com/sollertia/habit/domain/user/controller/UserController.java
+++ b/src/main/java/com/sollertia/habit/domain/user/controller/UserController.java
@@ -46,6 +46,14 @@ public class UserController {
     }
 
     @ApiOperation(value = "특정 유저 정보 조회", notes = "사용자, 몬스터, 습관 정보 응답")
+    @GetMapping("/user/detail")
+    public MyPageResponseDto getUserDetailInfo(
+            @ApiIgnore @AuthenticationPrincipal UserDetailsImpl userDetails
+    ) {
+        return userService.getUserDetailDto(userDetails.getUser());
+    }
+
+    @ApiOperation(value = "특정 유저 정보 조회", notes = "사용자, 몬스터, 습관 정보 응답")
     @GetMapping("/user/{monsterCode}/info")
     public UserDetailResponseDto getUserInfoByMonsterCode(
             @PathVariable String monsterCode,

--- a/src/main/java/com/sollertia/habit/domain/user/dto/RecommendationResponseVo.java
+++ b/src/main/java/com/sollertia/habit/domain/user/dto/RecommendationResponseVo.java
@@ -1,0 +1,12 @@
+package com.sollertia.habit.domain.user.dto;
+
+import com.sollertia.habit.domain.user.follow.dto.FollowSearchResponseVo;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class RecommendationResponseVo {
+    private String title;
+    private FollowSearchResponseVo userInfo;
+}

--- a/src/main/java/com/sollertia/habit/domain/user/dto/RecommendedUserListDto.java
+++ b/src/main/java/com/sollertia/habit/domain/user/dto/RecommendedUserListDto.java
@@ -1,6 +1,5 @@
 package com.sollertia.habit.domain.user.dto;
 
-import com.sollertia.habit.domain.user.follow.dto.FollowSearchResponseVo;
 import com.sollertia.habit.global.utils.DefaultResponseDto;
 import lombok.experimental.SuperBuilder;
 
@@ -8,5 +7,5 @@ import java.util.List;
 
 @SuperBuilder
 public class RecommendedUserListDto extends DefaultResponseDto {
-    private List<FollowSearchResponseVo> userList;
+    private List<RecommendationResponseVo> userList;
 }

--- a/src/main/java/com/sollertia/habit/domain/user/dto/UserDetailsVo.java
+++ b/src/main/java/com/sollertia/habit/domain/user/dto/UserDetailsVo.java
@@ -9,7 +9,8 @@ public class UserDetailsVo {
     private String monsterCode;
     private String username;
     private String email;
-    private boolean isFollowed;
+    private Boolean isFollowed;
+    private Integer totalHabitCount;
     private Integer followersCount;
     private Integer followingsCount;
 }

--- a/src/main/java/com/sollertia/habit/domain/user/dto/UserInfoVo.java
+++ b/src/main/java/com/sollertia/habit/domain/user/dto/UserInfoVo.java
@@ -1,5 +1,6 @@
 package com.sollertia.habit.domain.user.dto;
 
+import com.sollertia.habit.domain.user.entity.User;
 import com.sollertia.habit.domain.user.enums.ProviderType;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,4 +13,24 @@ public class UserInfoVo {
     private String email;
     private ProviderType socialType;
     private String monsterName;
+
+    public static UserInfoVo of(User user) {
+        if ( user.getMonster() == null ) {
+            return UserInfoVo.builder()
+                    .monsterCode(user.getMonsterCode())
+                    .email(user.getEmail())
+                    .username(user.getUsername())
+                    .socialType(user.getProviderType())
+                    .monsterName(null)
+                    .build();
+        } else {
+            return UserInfoVo.builder()
+                    .monsterCode(user.getMonsterCode())
+                    .email(user.getEmail())
+                    .username(user.getUsername())
+                    .socialType(user.getProviderType())
+                    .monsterName(user.getMonster().getName())
+                    .build();
+        }
+    }
 }

--- a/src/main/java/com/sollertia/habit/domain/user/follow/dto/FollowSearchResponseVo.java
+++ b/src/main/java/com/sollertia/habit/domain/user/follow/dto/FollowSearchResponseVo.java
@@ -7,8 +7,7 @@ import lombok.Getter;
 @Getter
 @Builder
 public class FollowSearchResponseVo {
-    private String email;
-    private String monsterName;
+    private String nickName;
     private Long monsterId;
     private String monsterImg;
     private String monsterCode;
@@ -17,9 +16,8 @@ public class FollowSearchResponseVo {
     public static FollowSearchResponseVo
     of(User searchUser, Boolean checkFollow){
         return FollowSearchResponseVo.builder()
-                .email(searchUser.getEmail() != null ? searchUser.getEmail() : searchUser.getUsername())
+                .nickName(searchUser.getUsername())
                 .monsterId(searchUser.getMonster().getMonsterDatabase().getId())
-                .monsterName(searchUser.getMonster().getName())
                 .monsterCode(searchUser.getMonsterCode())
                 .isFollowed(checkFollow)
                 .monsterImg(searchUser.getMonster().getMonsterDatabase().getImageUrl())

--- a/src/main/java/com/sollertia/habit/domain/user/follow/dto/FollowSearchResponseVo.java
+++ b/src/main/java/com/sollertia/habit/domain/user/follow/dto/FollowSearchResponseVo.java
@@ -14,7 +14,8 @@ public class FollowSearchResponseVo {
     private String monsterCode;
     private Boolean isFollowed;
 
-    public static FollowSearchResponseVo of(User searchUser, Boolean checkFollow){
+    public static FollowSearchResponseVo
+    of(User searchUser, Boolean checkFollow){
         return FollowSearchResponseVo.builder()
                 .email(searchUser.getEmail() != null ? searchUser.getEmail() : searchUser.getUsername())
                 .monsterId(searchUser.getMonster().getMonsterDatabase().getId())

--- a/src/main/java/com/sollertia/habit/domain/user/follow/dto/FollowVo.java
+++ b/src/main/java/com/sollertia/habit/domain/user/follow/dto/FollowVo.java
@@ -9,8 +9,7 @@ import lombok.Getter;
 @Builder
 public class FollowVo {
 
-    private String email;
-    private String monsterName;
+    private String nickName;
     private Long monsterId;
     private String monsterImg;
     private String monsterCode;
@@ -19,8 +18,7 @@ public class FollowVo {
     public static FollowVo followerOf(Follow follower, Boolean checkFollow) {
         User followerUser = follower.getFollower();
         return FollowVo.builder()
-                .email(followerUser.getEmail() != null ? followerUser.getEmail() : followerUser.getUsername())
-                .monsterName(followerUser.getMonster().getName())
+                .nickName(followerUser.getUsername())
                 .monsterId(followerUser.getMonster().getMonsterDatabase().getId())
                 .monsterCode(followerUser.getMonsterCode())
                 .isFollowed(checkFollow)
@@ -31,9 +29,9 @@ public class FollowVo {
     public static FollowVo followingOf(Follow following) {
         User followingUser = following.getFollowing();
         return FollowVo.builder()
-                .email(followingUser.getEmail() != null ? followingUser.getEmail() : followingUser.getUsername())
-                .monsterName(followingUser.getMonster().getName())
+                .nickName(followingUser.getUsername())
                 .monsterCode(followingUser.getMonsterCode())
+                .monsterId(followingUser.getMonster().getMonsterDatabase().getId())
                 .isFollowed(true)
                 .monsterImg(followingUser.getMonster().getMonsterDatabase().getImageUrl())
                 .build();
@@ -42,9 +40,9 @@ public class FollowVo {
     public static FollowVo followingOf(Follow following, Boolean checkFollow) {
         User followingUser = following.getFollowing();
         return FollowVo.builder()
-                .email(followingUser.getEmail() != null ? followingUser.getEmail() : followingUser.getUsername())
-                .monsterName(followingUser.getMonster().getName())
+                .nickName(followingUser.getUsername())
                 .monsterCode(followingUser.getMonsterCode())
+                .monsterId(followingUser.getMonster().getMonsterDatabase().getId())
                 .isFollowed(checkFollow)
                 .monsterImg(followingUser.getMonster().getMonsterDatabase().getImageUrl())
                 .build();

--- a/src/main/java/com/sollertia/habit/domain/user/follow/service/FollowServiceImpl.java
+++ b/src/main/java/com/sollertia/habit/domain/user/follow/service/FollowServiceImpl.java
@@ -17,7 +17,7 @@ import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
-public class FollowServiceImpl implements FollowService {
+public class  FollowServiceImpl implements FollowService {
 
     private final FollowRepository followRepository;
 

--- a/src/main/java/com/sollertia/habit/domain/user/recommendation/entity/Recommendation.java
+++ b/src/main/java/com/sollertia/habit/domain/user/recommendation/entity/Recommendation.java
@@ -1,0 +1,22 @@
+package com.sollertia.habit.domain.user.recommendation.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.sollertia.habit.domain.user.entity.User;
+import lombok.Getter;
+
+import javax.persistence.*;
+
+@Entity
+@Getter
+public class Recommendation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String title;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    @JsonIgnore
+    private User user;
+}

--- a/src/main/java/com/sollertia/habit/domain/user/recommendation/repository/RecommendationRepository.java
+++ b/src/main/java/com/sollertia/habit/domain/user/recommendation/repository/RecommendationRepository.java
@@ -1,0 +1,7 @@
+package com.sollertia.habit.domain.user.recommendation.repository;
+
+import com.sollertia.habit.domain.user.recommendation.entity.Recommendation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RecommendationRepository extends JpaRepository<Recommendation, Long> {
+}

--- a/src/main/java/com/sollertia/habit/domain/user/service/UserService.java
+++ b/src/main/java/com/sollertia/habit/domain/user/service/UserService.java
@@ -11,11 +11,11 @@ import com.sollertia.habit.domain.user.entity.User;
 import com.sollertia.habit.domain.user.follow.dto.FollowCount;
 import com.sollertia.habit.domain.user.follow.dto.FollowSearchResponseVo;
 import com.sollertia.habit.domain.user.follow.service.FollowServiceImpl;
+import com.sollertia.habit.domain.user.recommendation.entity.Recommendation;
+import com.sollertia.habit.domain.user.recommendation.repository.RecommendationRepository;
 import com.sollertia.habit.domain.user.repository.UserRepository;
 import com.sollertia.habit.global.exception.user.UserIdNotFoundException;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,6 +30,7 @@ public class UserService {
     private final FollowServiceImpl followService;
     private final MonsterService monsterService;
     private final HabitServiceImpl habitService;
+    private final RecommendationRepository recommendationRepository;
 
     public UserInfoResponseDto getUserInfoResponseDto(User user) {
         return UserInfoResponseDto.builder()
@@ -129,15 +130,15 @@ public class UserService {
     }
 
     public RecommendedUserListDto getRecommendedUserListDto(User user) {
-        List<FollowSearchResponseVo> userList = new ArrayList<>();
-        Page<User> userPage = userRepository.findAll(Pageable.ofSize(5));
+        List<RecommendationResponseVo> userList = new ArrayList<>();
+        List<Recommendation> recommendations = recommendationRepository.findAll();
 
-        for (User target : userPage) {
-            userList.add(
-                    FollowSearchResponseVo.of(
-                            target,
-                            followService.checkFollow(target.getMonsterCode(), user).getIsFollowed()
-                    ));
+        for (Recommendation recommendation : recommendations) {
+            FollowSearchResponseVo followSearchResponseVo = FollowSearchResponseVo.of(
+                    recommendation.getUser(),
+                    followService.checkFollow(recommendation.getUser().getMonsterCode(), user).getIsFollowed()
+            );
+            userList.add(new RecommendationResponseVo(recommendation.getTitle(), followSearchResponseVo));
         }
         return RecommendedUserListDto.builder()
                 .userList(userList)

--- a/src/main/java/com/sollertia/habit/domain/user/service/UserService.java
+++ b/src/main/java/com/sollertia/habit/domain/user/service/UserService.java
@@ -89,6 +89,8 @@ public class UserService {
         return MyPageResponseDto.builder()
                 .userInfo(getUserDetailsVo(user))
                 .monster(monster)
+                .responseMessage("User Info Query Completed")
+                .statusCode(200)
                 .build();
     }
 

--- a/src/test/java/com/sollertia/habit/domain/user/follow/controller/FollowControllerTest.java
+++ b/src/test/java/com/sollertia/habit/domain/user/follow/controller/FollowControllerTest.java
@@ -2,8 +2,8 @@ package com.sollertia.habit.domain.user.follow.controller;
 
 import com.sollertia.habit.domain.monster.entity.Monster;
 import com.sollertia.habit.domain.monster.entity.MonsterDatabase;
-import com.sollertia.habit.domain.monster.enums.MonsterType;
 import com.sollertia.habit.domain.monster.enums.Level;
+import com.sollertia.habit.domain.monster.enums.MonsterType;
 import com.sollertia.habit.domain.user.entity.User;
 import com.sollertia.habit.domain.user.follow.dto.*;
 import com.sollertia.habit.domain.user.follow.entity.Follow;
@@ -16,6 +16,9 @@ import com.sollertia.habit.global.utils.RedisUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.powermock.reflect.Whitebox;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -39,6 +42,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = FollowController.class)
+@RunWith(PowerMockRunner.class)
 class FollowControllerTest {
 
     @Autowired
@@ -95,6 +99,7 @@ class FollowControllerTest {
         authenticated();
         Follow follow = Follow.create(testUser2, testUser);
         FollowVo followerVo = FollowVo.followerOf(follow, true);
+        Whitebox.setInternalState(followerVo, "monsterId", 1L);
         List<FollowVo> followVos = new ArrayList<>();
         followVos.add(followerVo);
         FollowResponseDto followResponseDto = FollowResponseDto.builder().followers(followVos).statusCode(200).responseMessage("Followers Query Completed").build();
@@ -105,8 +110,8 @@ class FollowControllerTest {
                 .andDo(print())
                 //then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.followers[0].email").value("tester2.test.com"))
-                .andExpect(jsonPath("$.followers[0].monsterName").value("blue"))
+                .andExpect(jsonPath("$.followers[0].nickName").value("tester2"))
+                .andExpect(jsonPath("$.followers[0].monsterId").value(1L))
                 .andExpect(jsonPath("$.followers[0].monsterImg").value("blue.img"))
                 .andExpect(jsonPath("$.followers[0].monsterCode").value("monsterCode2"))
                 .andExpect(jsonPath("$.followers[0].isFollowed").value("true"))
@@ -123,6 +128,7 @@ class FollowControllerTest {
         authenticated();
         Follow follow = Follow.create(testUser, testUser2);
         FollowVo followingVo = FollowVo.followingOf(follow);
+        Whitebox.setInternalState(followingVo, "monsterId", 1L);
         List<FollowVo> followVos = new ArrayList<>();
         followVos.add(followingVo);
         FollowResponseDto followResponseDto = FollowResponseDto.builder().followings(followVos).statusCode(200).responseMessage("Followings Query Completed").build();
@@ -133,8 +139,8 @@ class FollowControllerTest {
                 .andDo(print())
                 //then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.followings[0].email").value("tester2.test.com"))
-                .andExpect(jsonPath("$.followings[0].monsterName").value("blue"))
+                .andExpect(jsonPath("$.followings[0].nickName").value("tester2"))
+                .andExpect(jsonPath("$.followings[0].monsterId").value(1L))
                 .andExpect(jsonPath("$.followings[0].monsterImg").value("blue.img"))
                 .andExpect(jsonPath("$.followings[0].monsterCode").value("monsterCode2"))
                 .andExpect(jsonPath("$.responseMessage").value("Followings Query Completed"))
@@ -189,6 +195,7 @@ class FollowControllerTest {
         //given
         authenticated();
         FollowSearchResponseVo responseVo = FollowSearchResponseVo.of(testUser2,false);
+        Whitebox.setInternalState(responseVo, "monsterId", 1L);
         FollowSearchResponseDto responseDto = FollowSearchResponseDto.builder().userInfo(responseVo).statusCode(200).responseMessage("Search Completed").build();
         given(followService.searchFollowing("1234G",testUser)).willReturn(responseDto);
 
@@ -197,10 +204,10 @@ class FollowControllerTest {
                 .andDo(print())
                 //then
                 .andExpect(status().isOk())
-                .andExpect(jsonPath("$.userInfo.monsterName").value(testUser2.getMonster().getName()))
                 .andExpect(jsonPath("$.userInfo.monsterImg").value(testUser2.getMonster().getMonsterDatabase().getImageUrl()))
                 .andExpect(jsonPath("$.userInfo.monsterCode").value(testUser2.getMonsterCode()))
-                .andExpect(jsonPath("$.userInfo.email").value(testUser2.getEmail()))
+                .andExpect(jsonPath("$.userInfo.monsterId").value("1"))
+                .andExpect(jsonPath("$.userInfo.nickName").value(testUser2.getUsername()))
                 .andExpect(jsonPath("$.userInfo.isFollowed").value("false"))
                 .andExpect(jsonPath("$.responseMessage").value("Search Completed"))
                 .andExpect(jsonPath("$.statusCode").value("200"));

--- a/src/test/java/com/sollertia/habit/domain/user/follow/service/FollowServiceImplTest.java
+++ b/src/test/java/com/sollertia/habit/domain/user/follow/service/FollowServiceImplTest.java
@@ -96,8 +96,7 @@ class FollowServiceImplTest {
 
         //then
         assertThat(followResponseDto.getFollowers().get(0).getIsFollowed()).isEqualTo(false);
-        assertThat(followResponseDto.getFollowers().get(0).getEmail()).isEqualTo(testUser2.getEmail());
-        assertThat(followResponseDto.getFollowers().get(0).getMonsterName()).isEqualTo(testUser2.getMonster().getName());
+        assertThat(followResponseDto.getFollowers().get(0).getNickName()).isEqualTo(testUser2.getUsername());
         assertThat(followResponseDto.getFollowers().get(0).getMonsterImg()).isEqualTo(testUser2.getMonster().getMonsterDatabase().getImageUrl());
         assertThat(followResponseDto.getFollowers().get(0).getMonsterCode()).isEqualTo(testUser2.getMonsterCode());
         assertThat(followResponseDto.getStatusCode()).isEqualTo(200);
@@ -117,8 +116,7 @@ class FollowServiceImplTest {
         FollowResponseDto followResponseDto = followService.getFollowings(testUser);
 
         //then
-        assertThat(followResponseDto.getFollowings().get(0).getEmail()).isEqualTo(testUser2.getEmail());
-        assertThat(followResponseDto.getFollowings().get(0).getMonsterName()).isEqualTo(testUser2.getMonster().getName());
+        assertThat(followResponseDto.getFollowings().get(0).getNickName()).isEqualTo(testUser2.getUsername());
         assertThat(followResponseDto.getFollowings().get(0).getMonsterImg()).isEqualTo(testUser2.getMonster().getMonsterDatabase().getImageUrl());
         assertThat(followResponseDto.getFollowings().get(0).getMonsterCode()).isEqualTo(testUser2.getMonsterCode());
         assertThat(followResponseDto.getStatusCode()).isEqualTo(200);
@@ -189,11 +187,10 @@ class FollowServiceImplTest {
         FollowSearchResponseDto responseDto = followService.searchFollowing(testUser2.getMonsterCode(), testUser);
 
         //then
-        assertThat(responseDto.getUserInfo().getEmail()).isEqualTo(testUser2.getEmail());
+        assertThat(responseDto.getUserInfo().getNickName()).isEqualTo(testUser2.getUsername());
         assertThat(responseDto.getUserInfo().getIsFollowed()).isEqualTo(false);
         assertThat(responseDto.getUserInfo().getMonsterCode()).isEqualTo(testUser2.getMonsterCode());
         assertThat(responseDto.getUserInfo().getMonsterImg()).isEqualTo(testUser2.getMonster().getMonsterDatabase().getImageUrl());
-        assertThat(responseDto.getUserInfo().getMonsterName()).isEqualTo(testUser2.getMonster().getName());
         assertThat(responseDto.getStatusCode()).isEqualTo(200);
         assertThat(responseDto.getResponseMessage()).isEqualTo("Search Completed");
     }


### PR DESCRIPTION
- 아래 6 개 API 응답 본문에 categoryId 추가
습관 생성 POST /habits
습관 상세 정보 요청 GET /habits/{habitId}
습관 변경 Patch /habits/{habitId}
습관 체크 GET /habits/check/{habitId}
사용자 습관 목록 조회 GET /user/habits
특정 유저 정보 조회 GET /user/{monsterCode}/info
- 마이페이지 조회용 GET /user/detail API 추가
- 사용자 상세 페이지, 마이페이지 요청 응답에 totalHabitCount 추가
- 유저 상세 페이지 습관 최근 생성순으로 정렬
- 추천 사용자 테이블 추가 (아직 데이터는 없음)
- 추천 사용자 조회 GET /users/recommended Response 변경
