### PR TITLE
사용자 API 응답 수정, 전체 습관 수, self 검색 null

### DIFF
--- a/src/main/java/com/sollertia/habit/domain/habit/dto/HabitSummaryListResponseDto.java
+++ b/src/main/java/com/sollertia/habit/domain/habit/dto/HabitSummaryListResponseDto.java
@@ -11,4 +11,5 @@ import java.util.List;
 @SuperBuilder
 public class HabitSummaryListResponseDto extends DefaultResponseDto {
     private List<HabitSummaryVo> habits;
+    private Integer totalHabitCount;
 }

--- a/src/main/java/com/sollertia/habit/domain/habit/service/HabitServiceImpl.java
+++ b/src/main/java/com/sollertia/habit/domain/habit/service/HabitServiceImpl.java
@@ -179,6 +179,7 @@ public class HabitServiceImpl implements HabitService {
     public HabitSummaryListResponseDto getHabitSummaryListResponseDto(User user) {
         return HabitSummaryListResponseDto.builder()
                 .habits(getHabitSummaryList(user))
+                .totalHabitCount(getAllHabitCountByUser(user))
                 .responseMessage("Habit Detail List Query Completed")
                 .statusCode(200)
                 .build();

--- a/src/main/java/com/sollertia/habit/domain/user/controller/UserController.java
+++ b/src/main/java/com/sollertia/habit/domain/user/controller/UserController.java
@@ -1,9 +1,6 @@
 package com.sollertia.habit.domain.user.controller;
 
-import com.sollertia.habit.domain.user.dto.RecommendedUserListDto;
-import com.sollertia.habit.domain.user.dto.UserDetailResponseDto;
-import com.sollertia.habit.domain.user.dto.UserInfoResponseDto;
-import com.sollertia.habit.domain.user.dto.UsernameUpdateRequestDto;
+import com.sollertia.habit.domain.user.dto.*;
 import com.sollertia.habit.domain.user.security.userdetail.UserDetailsImpl;
 import com.sollertia.habit.domain.user.service.UserService;
 import io.swagger.annotations.ApiOperation;

--- a/src/main/java/com/sollertia/habit/domain/user/dto/MyPageResponseDto.java
+++ b/src/main/java/com/sollertia/habit/domain/user/dto/MyPageResponseDto.java
@@ -1,4 +1,4 @@
-package com.sollertia.habit.domain.user.controller;
+package com.sollertia.habit.domain.user.dto;
 
 import com.sollertia.habit.domain.monster.dto.MonsterVo;
 import com.sollertia.habit.domain.user.dto.UserDetailsVo;

--- a/src/main/java/com/sollertia/habit/domain/user/dto/UserInfoVo.java
+++ b/src/main/java/com/sollertia/habit/domain/user/dto/UserInfoVo.java
@@ -10,25 +10,19 @@ import lombok.Getter;
 public class UserInfoVo {
     private String monsterCode;
     private String username;
-    private String email;
-    private ProviderType socialType;
     private String monsterName;
 
     public static UserInfoVo of(User user) {
         if ( user.getMonster() == null ) {
             return UserInfoVo.builder()
                     .monsterCode(user.getMonsterCode())
-                    .email(user.getEmail())
                     .username(user.getUsername())
-                    .socialType(user.getProviderType())
                     .monsterName(null)
                     .build();
         } else {
             return UserInfoVo.builder()
                     .monsterCode(user.getMonsterCode())
-                    .email(user.getEmail())
                     .username(user.getUsername())
-                    .socialType(user.getProviderType())
                     .monsterName(user.getMonster().getName())
                     .build();
         }

--- a/src/main/java/com/sollertia/habit/domain/user/follow/service/FollowServiceImpl.java
+++ b/src/main/java/com/sollertia/habit/domain/user/follow/service/FollowServiceImpl.java
@@ -84,7 +84,7 @@ public class  FollowServiceImpl implements FollowService {
     public FollowCheckDto requestFollow(String followingId, User user) {
 
         if(user.getMonsterCode().equals(followingId)){
-            throw new FollowException("You can't follow yourself");
+            return FollowCheckDto.builder().isFollowed(null).statusCode(400).responseMessage("You can't follow yourself").build();
         }
 
         User followingUser = getUserByMonsterCode(followingId);

--- a/src/main/java/com/sollertia/habit/domain/user/follow/service/FollowServiceImpl.java
+++ b/src/main/java/com/sollertia/habit/domain/user/follow/service/FollowServiceImpl.java
@@ -84,7 +84,7 @@ public class  FollowServiceImpl implements FollowService {
     public FollowCheckDto requestFollow(String followingId, User user) {
 
         if(user.getMonsterCode().equals(followingId)){
-            return FollowCheckDto.builder().isFollowed(null).statusCode(400).responseMessage("You can't follow yourself").build();
+            throw new FollowException("You can't follow yourself");
         }
 
         User followingUser = getUserByMonsterCode(followingId);

--- a/src/main/java/com/sollertia/habit/domain/user/follow/service/FollowServiceImpl.java
+++ b/src/main/java/com/sollertia/habit/domain/user/follow/service/FollowServiceImpl.java
@@ -113,6 +113,10 @@ public class  FollowServiceImpl implements FollowService {
     @Override
     public FollowSearchResponseDto searchFollowing(String followingId, User user) {
 
+        if(user.getMonsterCode().equals(followingId)){
+            return FollowSearchResponseDto.builder().userInfo(null).statusCode(400).responseMessage("You can't search yourself").build();
+        }
+
         Optional<User> searchUserOp = userRepository.findByMonsterCode(followingId);
 
         if(!searchUserOp.isPresent()){

--- a/src/main/java/com/sollertia/habit/domain/user/service/UserService.java
+++ b/src/main/java/com/sollertia/habit/domain/user/service/UserService.java
@@ -5,7 +5,7 @@ import com.sollertia.habit.domain.habit.service.HabitServiceImpl;
 import com.sollertia.habit.domain.monster.dto.MonsterVo;
 import com.sollertia.habit.domain.monster.entity.Monster;
 import com.sollertia.habit.domain.monster.service.MonsterService;
-import com.sollertia.habit.domain.user.controller.MyPageResponseDto;
+import com.sollertia.habit.domain.user.dto.MyPageResponseDto;
 import com.sollertia.habit.domain.user.dto.*;
 import com.sollertia.habit.domain.user.entity.User;
 import com.sollertia.habit.domain.user.follow.dto.FollowCount;

--- a/src/test/java/com/sollertia/habit/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/sollertia/habit/domain/user/controller/UserControllerTest.java
@@ -77,9 +77,7 @@ class UserControllerTest {
         authenticated();
         UserInfoVo infoVo = UserInfoVo.builder()
                 .monsterCode(testUser.getMonsterCode())
-                .email(testUser.getEmail())
                 .username(testUser.getUsername())
-                .socialType(testUser.getProviderType())
                 .build();
         UserInfoResponseDto responseDto = UserInfoResponseDto.builder()
                 .userInfo(infoVo)
@@ -93,10 +91,8 @@ class UserControllerTest {
         mvc.perform(get("/user/info"))
                 .andDo(print())
                 //then
-                .andExpect(jsonPath("$.userInfo.email").value(testUser.getEmail()))
                 .andExpect(jsonPath("$.userInfo.username").value(testUser.getUsername()))
                 .andExpect(jsonPath("$.userInfo.monsterCode").value(testUser.getMonsterCode()))
-                .andExpect(jsonPath("$.userInfo.socialType").value(testUser.getProviderType().toString()))
                 .andExpect(jsonPath("$.responseMessage").value("User Info Query Completed"))
                 .andExpect(jsonPath("$.statusCode").value("200"));
 

--- a/src/test/java/com/sollertia/habit/domain/user/follow/service/FollowServiceImplTest.java
+++ b/src/test/java/com/sollertia/habit/domain/user/follow/service/FollowServiceImplTest.java
@@ -143,8 +143,11 @@ class FollowServiceImplTest {
     void selfFollow() {
         //given
         //when
-        assertThrows(FollowException.class,
-                () -> followService.requestFollow(testUser2.getMonsterCode(), testUser2));
+        FollowCheckDto responseDto = followService.requestFollow(testUser2.getMonsterCode(), testUser2);
+        //when
+        assertThat(responseDto.getIsFollowed()).isEqualTo(null);
+        assertThat(responseDto.getStatusCode()).isEqualTo(400);
+        assertThat(responseDto.getResponseMessage()).isEqualTo("You can't follow yourself");
     }
 
     @DisplayName("Already Follow")

--- a/src/test/java/com/sollertia/habit/domain/user/follow/service/FollowServiceImplTest.java
+++ b/src/test/java/com/sollertia/habit/domain/user/follow/service/FollowServiceImplTest.java
@@ -143,11 +143,8 @@ class FollowServiceImplTest {
     void selfFollow() {
         //given
         //when
-        FollowCheckDto responseDto = followService.requestFollow(testUser2.getMonsterCode(), testUser2);
-        //when
-        assertThat(responseDto.getIsFollowed()).isEqualTo(null);
-        assertThat(responseDto.getStatusCode()).isEqualTo(400);
-        assertThat(responseDto.getResponseMessage()).isEqualTo("You can't follow yourself");
+        assertThrows(FollowException.class,
+                () -> followService.requestFollow(testUser2.getMonsterCode(), testUser2));
     }
 
     @DisplayName("Already Follow")

--- a/src/test/java/com/sollertia/habit/domain/user/follow/service/FollowServiceImplTest.java
+++ b/src/test/java/com/sollertia/habit/domain/user/follow/service/FollowServiceImplTest.java
@@ -195,6 +195,19 @@ class FollowServiceImplTest {
         assertThat(responseDto.getResponseMessage()).isEqualTo("Search Completed");
     }
 
+    @DisplayName("searchFollowing mySelf")
+    @Test
+    void searchFollowingMyself() {
+        //given
+        //when
+        FollowSearchResponseDto responseDto = followService.searchFollowing(testUser2.getMonsterCode(), testUser2);
+
+        //then
+        assertThat(responseDto.getUserInfo()).isEqualTo(null);
+        assertThat(responseDto.getStatusCode()).isEqualTo(400);
+        assertThat(responseDto.getResponseMessage()).isEqualTo("You can't search yourself");
+    }
+
     @DisplayName("Follow UserNoFound")
     @Test
     void followUserNotFound() {

--- a/src/test/java/com/sollertia/habit/domain/user/service/UserServiceTest.java
+++ b/src/test/java/com/sollertia/habit/domain/user/service/UserServiceTest.java
@@ -62,10 +62,8 @@ class UserServiceTest {
         //then
         assertThat(responseDto.getStatusCode()).isEqualTo(200);
         assertThat(responseDto.getResponseMessage()).isEqualTo("User Info Query Completed");
-        assertThat(responseDto.getUserInfo().getEmail()).isEqualTo(testUser.getEmail());
         assertThat(responseDto.getUserInfo().getUsername()).isEqualTo(testUser.getUsername());
         assertThat(responseDto.getUserInfo().getMonsterCode()).isEqualTo(testUser.getMonsterCode());
-        assertThat(responseDto.getUserInfo().getSocialType()).isEqualTo(testUser.getProviderType());
     }
 
     @Test


### PR DESCRIPTION
- 소셜타입, 이메일 응답 본문에서 제거
사용자 정보 조회 GET /user/info
사용자 이름 수정 GET /user/name
회원 탈퇴 DELETE /user
- GET /user/habits 응답 본문에 totalHabitCount 추가
- 자신을 검색하면 isFollow = null