### PR TITLE
빌드에러 해결2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,16 +25,10 @@ jobs:
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
       
-    - name: querydsl compile error fix try 1
-      run: gradle clean
-
-    # Test는 따로
+    # 빌드
     - name: Build with Gradle
-      run: ./gradlew build -x test
+      run: ./gradlew build
 
-    # 테스트 실행
-    - name: Test with Gradle
-      run: SPRING_PROFILES_ACTIVE=[test] ./gradlew test
 
     # 테스트 완료시 정보 저장
     - name: Publish Unit Test Results
@@ -50,6 +44,7 @@ jobs:
       with:
         format: YYYY-MM-DDTHH-mm-ss
         utcOffset: "+09:00"
+        
     # 배포 준비 - 빌드된 파일과 eb 환경 설정 관련 파일들 패키지로 묶어 zip으로 만들어서 보내줘야함
     # sed -i ~ 구문 : properies파일 암호화 풀기 위해서는 jasypt decode 키를 포함해서 빌드 명령을 내줘야함 그러기 위해 프로젝트에 저장된 빌드명령 변경
     - name: Generate deployment package 


### PR DESCRIPTION
지금 build.gradle은 querydsl 컴파일 패키지를 지웁니다.
그러나 github actions는 빌드와 테스트를 분리하게 되어 있고 그 과정에서 테스트가 돌 때 querydsl 컴파일 파일이 삭제되어 오류가 나는 것 같습니다.
그래서 빌드와 테스트를 한번에 진행해보겠습니다