### PR TITLE
FixJwt: Token 이 없을 때 Null 처리 추가

### DIFF
--- a/src/main/java/com/sollertia/habit/domain/user/security/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/sollertia/habit/domain/user/security/jwt/filter/JwtAuthenticationFilter.java
@@ -93,6 +93,10 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 createRequest(request, "refreshToken Malformed", request.getRequestURI(), messageBody, method, 401);
                 throw ex;
             }
+        } else {
+            messageBody = getBody(request);
+            createRequest(request, "Token is Null", request.getRequestURI(), messageBody, method, 401);
+            throw new NullPointerException("Token is Null");
         }
 
         filterChain.doFilter(request,response);

--- a/src/test/java/com/sollertia/habit/domain/notice/controller/NoticeControllerTest.java
+++ b/src/test/java/com/sollertia/habit/domain/notice/controller/NoticeControllerTest.java
@@ -12,6 +12,7 @@ import com.sollertia.habit.global.utils.RedisUtil;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -34,6 +35,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = NoticeController.class)
+@AutoConfigureMockMvc(addFilters = false)
 class NoticeControllerTest {
 
     @Autowired

--- a/src/test/java/com/sollertia/habit/domain/user/follow/controller/FollowControllerTest.java
+++ b/src/test/java/com/sollertia/habit/domain/user/follow/controller/FollowControllerTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.runner.RunWith;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.security.authentication.AuthenticationManager;
@@ -44,6 +45,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(controllers = FollowController.class)
+@AutoConfigureMockMvc(addFilters = false)
 @RunWith(PowerMockRunner.class)
 class FollowControllerTest {
 

--- a/src/test/java/com/sollertia/habit/domain/user/security/jwt/filter/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/sollertia/habit/domain/user/security/jwt/filter/JwtAuthenticationFilterTest.java
@@ -196,5 +196,15 @@ class JwtAuthenticationFilterTest {
                 () -> jwtAuthenticationFilter.doFilterInternal(request, response, chain));
     }
 
+    @DisplayName("Token is Null")
+    @Test
+    void tokenIsNull() {
+        //given
+        request.setRequestURI("/test");
+        request.setMethod("GET");
+        assertThrows(NullPointerException.class,
+                () -> jwtAuthenticationFilter.doFilterInternal(request, response, chain));
+    }
+
 
 }


### PR DESCRIPTION
유저가 강제로 Token을 삭제한 경우 Null 처리 반영 -> client에서 로그인페이지로 이동시킬 때 사용