### PR TITLE
Redis 캐싱에서 로컬 EHCache3로 교체

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,11 @@ dependencies {
 
     //redis
     implementation 'org.springframework.boot:spring-boot-starter-data-redis:2.5.3'
+
+    //cache
     implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'org.ehcache:ehcache:3.8.0'
+    implementation 'javax.cache:cache-api:1.0.0'
 
     //fix enum nullable (enum.When)
     implementation 'com.google.code.findbugs:jsr305:3.0.2'

--- a/src/main/java/com/sollertia/habit/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/sollertia/habit/domain/category/controller/CategoryController.java
@@ -13,7 +13,7 @@ import java.util.List;
 @RestController
 public class CategoryController {
 
-    @Cacheable(value = "Categories", key = "1")
+    @Cacheable(cacheNames = "categories")
     @ApiOperation(value = "Category 목록 조회")
     @GetMapping("/categories")
     public CategoryResponseDto categoryPresetList() {

--- a/src/main/java/com/sollertia/habit/domain/category/dto/CategoryDto.java
+++ b/src/main/java/com/sollertia/habit/domain/category/dto/CategoryDto.java
@@ -6,11 +6,13 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
+
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class CategoryDto {
+public class CategoryDto implements Serializable{
     private Long categoryId;
     private Category category;
 }

--- a/src/main/java/com/sollertia/habit/domain/category/dto/CategoryResponseDto.java
+++ b/src/main/java/com/sollertia/habit/domain/category/dto/CategoryResponseDto.java
@@ -2,15 +2,18 @@ package com.sollertia.habit.domain.category.dto;
 
 
 import com.sollertia.habit.global.utils.DefaultResponseDto;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.io.Serializable;
 import java.util.List;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 @SuperBuilder
-public class CategoryResponseDto extends DefaultResponseDto {
+public class CategoryResponseDto extends DefaultResponseDto implements Serializable{
         private List<CategoryDto> categories;
 }

--- a/src/main/java/com/sollertia/habit/domain/preset/controller/PreSetController.java
+++ b/src/main/java/com/sollertia/habit/domain/preset/controller/PreSetController.java
@@ -30,7 +30,7 @@ public class PreSetController {
     private final PreSetServiceImpl preSetService;
     private final HabitServiceImpl habitService;
 
-    @Cacheable(key = "#category_id",value = "PreSet")
+    @Cacheable(cacheNames = "PreSet", key = "#category_id")
     @ApiOperation(value = "선택한 Category의 PreSet 목록 조회")
     @GetMapping("/categories/{category_id}/presets")
     public PreSetResponseDto categoryPreSetList(@PathVariable Long category_id){

--- a/src/main/java/com/sollertia/habit/domain/preset/dto/PreSetDto.java
+++ b/src/main/java/com/sollertia/habit/domain/preset/dto/PreSetDto.java
@@ -8,13 +8,14 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.io.Serializable;
 import java.time.Duration;
 
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class PreSetDto {
+public class PreSetDto implements Serializable {
     private Long presetId;
     private Long categoryId;
     private String title;

--- a/src/main/java/com/sollertia/habit/domain/preset/dto/PreSetResponseDto.java
+++ b/src/main/java/com/sollertia/habit/domain/preset/dto/PreSetResponseDto.java
@@ -2,15 +2,18 @@ package com.sollertia.habit.domain.preset.dto;
 
 
 import com.sollertia.habit.global.utils.DefaultResponseDto;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
+import java.io.Serializable;
 import java.util.List;
 
 @Getter
 @NoArgsConstructor
+@AllArgsConstructor
 @SuperBuilder
-public class PreSetResponseDto extends DefaultResponseDto {
+public class PreSetResponseDto extends DefaultResponseDto implements Serializable {
     private List<PreSetDto> preSets;
 }

--- a/src/main/java/com/sollertia/habit/global/config/CachingConfig.java
+++ b/src/main/java/com/sollertia/habit/global/config/CachingConfig.java
@@ -3,8 +3,12 @@ package com.sollertia.habit.global.config;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.cache.ehcache.EhCacheCacheManager;
+import org.springframework.cache.jcache.JCacheCacheManager;
+import org.springframework.cache.jcache.JCacheManagerFactoryBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.data.redis.cache.RedisCacheConfiguration;
 import org.springframework.data.redis.cache.RedisCacheManager;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -18,16 +22,17 @@ import java.time.Duration;
 @EnableCaching
 public class CachingConfig {
 
-    @Autowired
-    RedisConnectionFactory ConnectionFactory;
+    @Bean
+    public JCacheManagerFactoryBean jCacheManagerFactoryBean() throws Exception{
+        JCacheManagerFactoryBean jCacheManagerFactoryBean = new JCacheManagerFactoryBean();
+        jCacheManagerFactoryBean.setCacheManagerUri(new ClassPathResource("ehcache.xml").getURI());
+        return jCacheManagerFactoryBean;
+    }
 
     @Bean
-    public CacheManager redisCacheManager() {
-        RedisCacheConfiguration redisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()
-                .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer()))
-                .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(new GenericJackson2JsonRedisSerializer()))
-                .entryTtl(Duration.ofDays(2));
-
-        return RedisCacheManager.RedisCacheManagerBuilder.fromConnectionFactory(ConnectionFactory).cacheDefaults(redisCacheConfiguration).build();
+    public JCacheCacheManager jCacheCacheManager(JCacheManagerFactoryBean jCacheManagerFactoryBean) {
+        JCacheCacheManager jCacheCacheManager = new JCacheCacheManager();
+        jCacheCacheManager.setCacheManager(jCacheManagerFactoryBean.getObject());
+        return jCacheCacheManager;
     }
 }

--- a/src/main/resources/application-local.properties
+++ b/src/main/resources/application-local.properties
@@ -21,3 +21,6 @@ jwt.secret.key=ENC(Qyh6Pjf1UMe8Vm/Oogh6pg==)
 
 oauth2.kakao.client_id=1e34b375275185ed61e3c5fa66420117
 oauth2.kakao.redirect_url=http://localhost:3000/login
+
+# EHCache3 설정
+spring.cache.jcache.config=classpath:ehcache.xml

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -22,3 +22,6 @@ jwt.secret.key=ENC(Qyh6Pjf1UMe8Vm/Oogh6pg==)
 
 oauth2.kakao.client_id=ENC(zW7YEARRzYHywl0fKaGU51XVh2Xa+XXnC4d0VOO+5rkBVnKAFbGPUFxf4XUYPQmp)
 oauth2.kakao.redirect_url=https://habitmonster.app/login
+
+# EHCache3 설정
+spring.cache.jcache.config=classpath:ehcache.xml

--- a/src/main/resources/ehcache.xml
+++ b/src/main/resources/ehcache.xml
@@ -1,0 +1,30 @@
+<config
+        xmlns:xsi='http://www.w3.org/2001/XMLSchema-instance'
+        xmlns='http://www.ehcache.org/v3'
+        xmlns:jsr107="http://www.ehcache.org/v3/jsr107"
+        xsi:schemaLocation="http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core.xsd
+http://www.ehcache.org/v3/jsr107 http://www.ehcache.org/schema/ehcache-107-ext-3.0.xsd">
+    <service>
+        <jsr107:defaults enable-management="true" enable-statistics="true"/>
+    </service>
+
+    <cache-template name="category">
+        <resources>
+            <heap unit="entries">20</heap>
+            <offheap unit="MB">10</offheap>
+        </resources>
+    </cache-template>
+    <cache-template name="preSet">
+        <expiry>
+            <ttl unit="seconds">172800</ttl>
+        </expiry>
+        <resources>
+            <heap unit="entries">20</heap>
+            <offheap unit="MB">10</offheap>
+        </resources>
+    </cache-template>
+    <cache alias="categories" uses-template="category">
+    </cache>
+    <cache alias="PreSet" uses-template="preSet">
+    </cache>
+</config>


### PR DESCRIPTION
Category 와 PreSet 관련 ElastiCache Redis 로 캐싱하여 관리하는 것을 로컬 캐시인 EHCache3로 변경
동기화가 느리다는 단점이 있지만 이를 해결하기 위해 카테고리는 변경이 없기 때문에 상관이 없고 1주일마다 변경이 있는 PreSet은 TTL을 부여하여 2일에 한번씩 최신화가 가능하도록 설정 하였습니다.
- @Cacheable value 보다 최신버전 설정인 cacheNames 사용
- DTO Serializable 설정 추가
- EHCache에서 지원하는 JSR-107 표준을 따르는 Jcache 사용하여 설정
- EHCache3 설정 내용인 ehcache.xml 추가