### PR TITLE
RefEHCache : Serializable 직렬화 문제 해결

### DIFF
--- a/src/main/java/com/sollertia/habit/domain/category/dto/CategoryResponseDto.java
+++ b/src/main/java/com/sollertia/habit/domain/category/dto/CategoryResponseDto.java
@@ -1,11 +1,10 @@
 package com.sollertia.habit.domain.category.dto;
 
 
-import com.sollertia.habit.global.utils.DefaultResponseDto;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.experimental.SuperBuilder;
 
 import java.io.Serializable;
 import java.util.List;
@@ -13,7 +12,9 @@ import java.util.List;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
-@SuperBuilder
-public class CategoryResponseDto extends DefaultResponseDto implements Serializable{
+@Builder
+public class CategoryResponseDto implements Serializable{
         private List<CategoryDto> categories;
+        private Integer statusCode;
+        private String responseMessage;
 }

--- a/src/main/java/com/sollertia/habit/domain/preset/dto/PreSetResponseDto.java
+++ b/src/main/java/com/sollertia/habit/domain/preset/dto/PreSetResponseDto.java
@@ -1,7 +1,6 @@
 package com.sollertia.habit.domain.preset.dto;
 
 
-import com.sollertia.habit.global.utils.DefaultResponseDto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,6 +13,8 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 @SuperBuilder
-public class PreSetResponseDto extends DefaultResponseDto implements Serializable {
+public class PreSetResponseDto implements Serializable {
     private List<PreSetDto> preSets;
+    private Integer statusCode;
+    private String responseMessage;
 }


### PR DESCRIPTION
Serializable 직렬화 해줄 때 extends 한 DefalutResponseDto의 값은 직렬화를 해주지 못하는 문제가 발생하여 
DefalutResponseDto 사용 제거